### PR TITLE
Bug/sign in with email case insensitive

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -94,7 +94,7 @@ export const signUpWithEmailNPassword = (
       const newGemmer: Gemmer = {
         id: user.uid,
         username: username,
-        email: email,
+        email: email.toLowerCase(),
         bio: "",
         image: "",
         joinningDate: Timestamp.now(),

--- a/src/utils/helpers/checkIfEmailHasBeenRegistered.ts
+++ b/src/utils/helpers/checkIfEmailHasBeenRegistered.ts
@@ -4,7 +4,10 @@ import { db } from "../../config/firebase";
 export default async function checkIfEmailHasBeenRegistered(
   email: string
 ): Promise<boolean> {
-  const q = query(collection(db, "gemmers"), where("email", "==", email));
+  const q = query(
+    collection(db, "gemmers"),
+    where("email", "==", email.toLowerCase())
+  );
 
   const querySnapshot = await getDocs(q);
 


### PR DESCRIPTION
When users are signing in with their email, the checking of whether the email has been registered already for an account should be case-insensitive.